### PR TITLE
Update outdated blockgen config

### DIFF
--- a/benchmarks/remote-read/manifests/prometheus-rr-streamed.yaml
+++ b/benchmarks/remote-read/manifests/prometheus-rr-streamed.yaml
@@ -109,7 +109,7 @@ spec:
           name: prometheus-rr-streamed
       initContainers:
       - args:
-        - blockgen
+        - walgen
         - |-
           --config={
             "InputSeries": [
@@ -149,11 +149,11 @@ spec:
             "Retention": 36000000000000,
             "ScrapeInterval": 0
           }
-        - --output-dir=/data-shared/prometheus
+        - --output.dir=/data-shared/prometheus
         command:
         - /bin/thanosbench
         image: quay.io/thanos/thanosbench:docker-2019-10-04-19e823a
-        name: blockgen
+        name: walgen
         resources:
           limits:
             cpu: "1"

--- a/benchmarks/remote-read/manifests/prometheus.yaml
+++ b/benchmarks/remote-read/manifests/prometheus.yaml
@@ -109,7 +109,7 @@ spec:
           name: prometheus
       initContainers:
       - args:
-        - blockgen
+        - walgen
         - |-
           --config={
             "InputSeries": [
@@ -149,11 +149,11 @@ spec:
             "Retention": 36000000000000,
             "ScrapeInterval": 0
           }
-        - --output-dir=/data-shared/prometheus
+        - --output.dir=/data-shared/prometheus
         command:
         - /bin/thanosbench
         image: quay.io/thanos/thanosbench:docker-2019-10-04-19e823a
-        name: blockgen
+        name: walgen
         resources:
           limits:
             cpu: "1"

--- a/configs/kubernetes/prometheus.go
+++ b/configs/kubernetes/prometheus.go
@@ -249,8 +249,8 @@ type PrometheusOpts struct {
 	Resources corev1.ResourceRequirements
 
 	// If empty, no data autogeneration will be defined.
-	BlockgenConfig *walgen.Config
-	BlockgenImg    dockerimage.Image
+	WalGenConfig *walgen.Config
+	WalGenImg    dockerimage.Image
 
 	ThanosImg       dockerimage.Image
 	ThanosResources corev1.ResourceRequirements
@@ -454,15 +454,15 @@ func GenPrometheus(gen *mimic.Generator, opts PrometheusOpts) {
 	}
 
 	var initContainers []corev1.Container
-	if opts.BlockgenConfig != nil {
+	if opts.WalGenConfig != nil {
 		initContainers = append(initContainers, corev1.Container{
-			Name:    "blockgen",
-			Image:   opts.BlockgenImg.String(),
+			Name:    "walgen",
+			Image:   opts.WalGenImg.String(),
 			Command: []string{"/bin/thanosbench"},
 			Args: []string{
-				"blockgen",
-				fmt.Sprintf("--config=%s", string(genInPlace(encoding.JSON(*opts.BlockgenConfig)))),
-				fmt.Sprintf("--output-dir=%s", promDataPath),
+				"walgen",
+				fmt.Sprintf("--config=%s", string(genInPlace(encoding.JSON(*opts.WalGenConfig)))),
+				fmt.Sprintf("--output.dir=%s", promDataPath),
 			},
 			VolumeMounts: []corev1.VolumeMount{sharedVM.VolumeMount},
 			Resources: corev1.ResourceRequirements{

--- a/configs/kubernetes/remote-read.go
+++ b/configs/kubernetes/remote-read.go
@@ -30,9 +30,9 @@ func GenRemoteReadBenchPrometheus(gen *mimic.Generator, name string, namespace s
 				},
 			},
 		},
-		BlockgenImg: dockerimage.Image{Organization: "quay.io/thanos", Project: "thanosbench", Version: "docker-2019-10-04-19e823a"},
+		WalGenImg: dockerimage.Image{Organization: "quay.io/thanos", Project: "thanosbench", Version: "docker-2019-10-04-19e823a"},
 		// Generate 10k series of type gauge on start.
-		BlockgenConfig: &walgen.Config{
+		WalGenConfig: &walgen.Config{
 			InputSeries: []walgen.Series{
 				{
 					Type: "gauge",


### PR DESCRIPTION
Signed-off-by: yeya24 <yb532204897@gmail.com>

The `blockgen` config in https://github.com/thanos-io/thanosbench/blob/master/configs/kubernetes/prometheus.go#L462 is outdated since `thanosbench` doesn't have a `blockgen` command.

This pr replaces the `blockgen` config with `walgen`.